### PR TITLE
Jetson nano support

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -147,6 +147,7 @@ local build(board, arch, mode, distro) = {
         #{ name: "raspberrypi2", arch: "arm", type: "all" },
         { name: "odroid-xu3and4", arch: "arm", type: "all" },
         { name: "odroid-xu3and4", arch: "arm", type: "sd" },
+	    { name: "jetson-nano", arch: "arm64", type: "all" },
         #{ name: "odroid-c2", arch: "arm", type: "all" },
         #{ name: "odroid-u3", arch: "arm", type: "all" },
         #{ name: "bananapim2", arch: "arm", type: "all" },

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -147,7 +147,7 @@ local build(board, arch, mode, distro) = {
         #{ name: "raspberrypi2", arch: "arm", type: "all" },
         { name: "odroid-xu3and4", arch: "arm", type: "all" },
         { name: "odroid-xu3and4", arch: "arm", type: "sd" },
-	    { name: "jetson-nano", arch: "arm64", type: "all" },
+	{ name: "jetson-nano", arch: "arm64", type: "all" },
         #{ name: "odroid-c2", arch: "arm", type: "all" },
         #{ name: "odroid-u3", arch: "arm", type: "all" },
         #{ name: "bananapim2", arch: "arm", type: "all" },

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -5,10 +5,12 @@ echo "===== loop cleanup ====="
 ls -la /dev/mapper/*
 losetup || true
 
-mapper_arr=(`ls /dev/mapper/loop* 2>/dev/null`)
+mapper_arr=(`ls /dev/mapper/loop* 2>/dev/null || true`)
 if [[ ${#mapper_arr[@]} -gt 0 ]];then
  apt update && apt install -y dmsetup
  dmsetup remove -f /dev/mapper/loop* || true
 fi
 
-losetup -D || true
+
+loopdev_name=`losetup -O NAME,BACK-FILE | grep syncloud-*-$DRONE_TAG.img | cut -d " " -f 1`
+[[ -n $loopdev_name ]] && losetup -d $loopdev_name || true

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 echo "===== loop cleanup ====="
+apt update && apt install -y dmsetup
 ls -la /dev/mapper/*
 losetup || true
 dmsetup remove -f /dev/mapper/loop* || true

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,7 +1,14 @@
 #!/bin/bash -e
 
 echo "===== loop cleanup ====="
-apt update && apt install -y dmsetup
+
 ls -la /dev/mapper/*
 losetup || true
-dmsetup remove -f /dev/mapper/loop* || true
+
+mapper_arr=(`ls /dev/mapper/loop* 2>/dev/null`)
+if [[ ${#mapper_arr[@]} -gt 0 ]];then
+ apt update && apt install -y dmsetup
+ dmsetup remove -f /dev/mapper/loop* || true
+fi
+
+losetup -D || true

--- a/files/jetson-nano/etc/syncloud/id.cfg
+++ b/files/jetson-nano/etc/syncloud/id.cfg
@@ -1,0 +1,3 @@
+[id]
+name=jetson-nano
+title=Jetson Nano

--- a/tools/boot.sh
+++ b/tools/boot.sh
@@ -37,7 +37,11 @@ BOOT_BYTES=$(wc -c "${SYNCLOUD_IMAGE}" | cut -f 1 -d ' ')
 BOOT_SECTORS=$(( ${BOOT_BYTES} / 512 ))
 echo "boot sectors: ${BOOT_SECTORS}"
 ROOTFS_SECTORS=$( numfmt --from=iec --to-unit=512 $ROOTFS_SIZE )
-dd if=/dev/zero count=${ROOTFS_SECTORS} >> ${SYNCLOUD_IMAGE}
+COUNT_TO_ROOTFS=${ROOTFS_SECTORS}
+if [[ ${SYNCLOUD_BOARD} == "jetson-nano" ]];then
+  COUNT_TO_ROOTFS=$((${COUNT_TO_ROOTFS} + 2048))
+fi
+dd if=/dev/zero bs=512 count=${COUNT_TO_ROOTFS} >> ${SYNCLOUD_IMAGE}
 ROOTFS_START_SECTOR=$(( ${BOOT_SECTORS} + 1  ))
 ROOTFS_END_SECTOR=$(( ${ROOTFS_START_SECTOR} + ${ROOTFS_SECTORS} - 100 ))
 fdisk -l ${SYNCLOUD_IMAGE}

--- a/tools/boot.sh
+++ b/tools/boot.sh
@@ -38,9 +38,9 @@ BOOT_SECTORS=$(( ${BOOT_BYTES} / 512 ))
 echo "boot sectors: ${BOOT_SECTORS}"
 ROOTFS_SECTORS=$( numfmt --from=iec --to-unit=512 $ROOTFS_SIZE )
 COUNT_TO_ROOTFS=${ROOTFS_SECTORS}
-if [[ ${SYNCLOUD_BOARD} == "jetson-nano" ]];then
-  COUNT_TO_ROOTFS=$((${COUNT_TO_ROOTFS} + 2048))
-fi
+#if [[ ${SYNCLOUD_BOARD} == "jetson-nano" ]];then
+#  COUNT_TO_ROOTFS=$((${COUNT_TO_ROOTFS} + 2048))
+#fi
 dd if=/dev/zero bs=512 count=${COUNT_TO_ROOTFS} >> ${SYNCLOUD_IMAGE}
 ROOTFS_START_SECTOR=$(( ${BOOT_SECTORS} + 1  ))
 ROOTFS_END_SECTOR=$(( ${ROOTFS_START_SECTOR} + ${ROOTFS_SECTORS} - 100 ))

--- a/tools/extract.sh
+++ b/tools/extract.sh
@@ -123,6 +123,10 @@ elif [[ ${SYNCLOUD_BOARD} == "raspberrypi-64" ]]; then
   IMAGE_FILE="2022-09-06-raspios-bullseye-arm64-lite.img"
   IMAGE_FILE_ZIP=${IMAGE_FILE}.xz
   DOWNLOAD_IMAGE="wget --progress=dot:giga ${SYNCLOUD_DISTR_URL}/${IMAGE_FILE_ZIP}"
+elif [[ ${SYNCLOUD_BOARD} == "jetson-nano" ]]; then
+  IMAGE_FILE="Armbian_22.11.1_Jetson-nano_bullseye_current_5.19.17.img"
+  IMAGE_FILE_ZIP=${IMAGE_FILE}.xz
+  DOWNLOAD_IMAGE="wget --progress=dot:giga ${SYNCLOUD_DISTR_URL}/${IMAGE_FILE_ZIP}"
 else
     echo "board is not supported: ${SYNCLOUD_BOARD}"
     exit 1


### PR DESCRIPTION
This is solution part of issue syncloud/platform#668
Add Image support for Jetson Nano based on Armbian Bullseye Current([Armbian_22.11.1_Jetson-nano_bullseye_current_5.19.17.img](https://redirect.armbian.com/jetson-nano/Bullseye_current)).
Makes boot step to create larger than rootfs image size arg to solve usable size smaller than rootfs size problem in sgdisk when building for jetson-nano.
Makes cleanup setup can running standalone when any setup needs to cleanup.
